### PR TITLE
remove duplicate task on govuk

### DIFF
--- a/lib/waves/utilities/task.rb
+++ b/lib/waves/utilities/task.rb
@@ -93,8 +93,7 @@ module WavesUtilities
         [
           :new_registration, :renewal, :re_registration, :change_owner,
           :change_vessel, :change_address, :duplicate_certificate,
-          :change_address, :current_transcript, :historic_transcript,
-          :closure
+          :current_transcript, :historic_transcript, :closure
         ]
       end
 


### PR DESCRIPTION
Remove the duplicate entity from the service list on govuk